### PR TITLE
Change color scheme from grey to green

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,5 +1,5 @@
 body {
-    background-color: #5e686e;
+    background-color: #3e5e4a;
     font-family: 'Roboto', sans-serif;
 }
 

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 <body>
 
 	<!-- Nav bar -->
-	<nav class="navbar sticky-top navbar-expand-lg navbar-dark" style="background-color: #33393d">
+	<nav class="navbar sticky-top navbar-expand-lg navbar-dark" style="background-color: #2a3d31">
 
 		<a class="navbar-brand" href="#"><img src="assets/images/square_logo.png" width="30" height="30" alt="logo"></a>
 


### PR DESCRIPTION
## Before / After
The site background and navbar were slate grey; now they're forest green. Text and links stay white.

- Body background: `#5e686e` → `#3e5e4a` (muted forest green)
- Navbar background: `#33393d` → `#2a3d31` (dark forest green)

White-on-green contrast is ~7.5:1 (body) and ~11:1 (navbar), both above WCAG AAA.

## How
Two hex literals changed — one in `assets/css/styles.css`, one inline on the `<nav>` in `index.html`. No tokens/variables exist in this repo, so values are edited directly.

Logo/favicon images still use the old grey and are left as-is (out of scope).

---
_Generated by [Claude Code](https://claude.ai/code/session_015Hmat2AuR7geRwQRJZrZU2)_